### PR TITLE
use test config object

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,20 +8,11 @@
   ],
   "dependencies": {
     "purescript-prelude": "^3.1.1",
-    "purescript-web3": "^0.17.0",
-    "purescript-web3-generator": "git+https://github.com/f-o-a-m/purescript-web3-generator.git#0.17.2-beta",
-    "purescript-console": "^3.0.0",
-    "purescript-errors": "^3.0.0",
-    "purescript-node-process": "^5.0.0",
-    "purescript-debug": "^3.0.0",
-    "purescript-mkdirp": "git+https://github.com/f-o-a-m/purescript-mkdirp.git#v0.3.0",
-    "purescript-logging": "^2.0.0",
-    "purescript-now": "^3.0.0",
-    "purescript-validation": "^3.2.0"
+    "purescript-web3": "^0.17.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-chanterelle": "git+https://github.com/f-o-a-m/chanterelle#v0.3.0",
+    "purescript-chanterelle": "git+https://github.com/f-o-a-m/chanterelle#815b5b0d08c7d72b8740327fcb44e16cdfba1ac0",
     "purescript-spec": "^2.0.0"
   }
 }

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -12,7 +12,7 @@ import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Reader.Class (ask)
 import Data.Lens ((?~))
 import Data.Maybe (fromJust)
-import Network.Ethereum.Web3 (ETH, defaultTransactionOptions, _from, _gas)
+import Network.Ethereum.Web3 (Address, ETH, _from, _gas, defaultTransactionOptions)
 import Network.Ethereum.Web3.Types.BigNumber (parseBigNumber, decimal)
 import Node.FS.Aff (FS)
 import Node.Process (PROCESS)
@@ -21,14 +21,19 @@ import Partial.Unsafe (unsafePartial)
 main :: forall e. Eff (console :: CONSOLE, eth :: ETH, fs :: FS, process :: PROCESS, exception :: EXCEPTION | e) Unit
 main = deployMain deployScript
 
-deployScript :: forall eff. DeployM eff Unit
-deployScript = void $ do
+
+
+type DeployResults =
+  (foamCSR :: Address, simpleStorage :: Address, parkingAuthority :: Address)
+
+deployScript :: forall eff. DeployM eff (Record DeployResults)
+deployScript = do
   deployCfg@(DeployConfig {primaryAccount}) <- ask
   let bigGasLimit = unsafePartial fromJust $ parseBigNumber decimal "4712388"
       txOpts = defaultTransactionOptions # _from ?~ primaryAccount
                                          # _gas ?~ bigGasLimit
-  _ <- deployContract txOpts simpleStorageConfig
+  simpleStorage <- deployContract txOpts simpleStorageConfig
   foamCSR <- deployContract txOpts foamCSRConfig
   let parkingAuthorityConfig = makeParkingAuthorityConfig {foamCSR}
-  _ <- deployContract txOpts parkingAuthorityConfig
-  pure unit
+  parkingAuthority <- deployContract txOpts parkingAuthorityConfig
+  pure {foamCSR, simpleStorage, parkingAuthority}

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,26 +1,32 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Aff (launchAff)
+
+import Chanterelle.Internal.Test (TestConfig)
+import Chanterelle.Internal.Types (DeployConfig(..), DeployError(..), logDeployError, runDeployM)
+import Chanterelle.Internal.Utils (makeDeployConfig)
+import Control.Monad.Aff (Aff, launchAff, liftEff')
 import Control.Monad.Aff.AVar (AVAR)
+import Control.Monad.Aff.Class (liftAff)
 import Control.Monad.Aff.Console (CONSOLE)
 import Control.Monad.Aff.Unsafe (unsafeCoerceAff)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
+import Control.Monad.Eff.Exception (throw)
+import Control.Monad.Error.Class (throwError)
 import Control.Monad.Except (runExceptT)
+import Data.Either (Either(..), either)
 import Data.Maybe (Maybe(..))
-import Data.Either (Either(..))
-import Test.Spec.Reporter.Console (consoleReporter)
-import Test.Spec.Runner (PROCESS, run', defaultConfig)
-import Network.Ethereum.Web3 (ETH)
+import Data.Tuple (Tuple(..))
+import Main (DeployResults, deployScript)
+import Network.Ethereum.Web3 (ETH, runWeb3)
+import Network.Ethereum.Web3.Api (eth_getAccounts)
 import Node.FS.Aff (FS)
 import Node.Process as NP
-
-import Chanterelle.Internal.Utils (makeDeployConfig)
-import Chanterelle.Internal.Types (logDeployError)
-
-import SimpleStorageSpec (simpleStorageSpec)
 import ParkingAuthoritySpec (parkingAuthoritySpec)
+import SimpleStorageSpec (simpleStorageSpec)
+import Test.Spec.Reporter.Console (consoleReporter)
+import Test.Spec.Runner (PROCESS, run', defaultConfig)
 
 -- | TODO: make the options for deploy config env vars
 main
@@ -34,10 +40,31 @@ main
          | e
          ) Unit
 main = void <<< launchAff $ do
-  edeployConfig <- unsafeCoerceAff <<< runExceptT $ makeDeployConfig "http://localhost:8545" 60
+  testConfig <- testDeployment "http://localhost:8545" 60
+  liftEff $ run' defaultConfig {timeout = Just (60 * 1000)} [consoleReporter] do
+    simpleStorageSpec testConfig
+    parkingAuthoritySpec testConfig
+
+testDeployment
+  :: forall eff.
+     String
+  -> Int
+  -> Aff (console :: CONSOLE, eth :: ETH, fs :: FS | eff) (TestConfig DeployResults)
+testDeployment url timeout = do
+  edeployConfig <- unsafeCoerceAff <<< runExceptT $ makeDeployConfig url timeout
   case edeployConfig of
-    Left err -> logDeployError err *> pure unit
-    Right deployConfig ->
-      liftEff $ run' defaultConfig {timeout = Just (60 * 1000)} [consoleReporter] do
-        simpleStorageSpec deployConfig
-        parkingAuthoritySpec deployConfig
+    Left err -> logDeployError err *> (liftEff' $ throw "Couldn't make deploy config for tests!")
+    Right deployConfig@(DeployConfig {provider}) -> do
+      eDeployResults <- flip runDeployM deployConfig $ do
+        eaccounts <- liftAff $ runWeb3 provider eth_getAccounts
+        accounts <- either (throwError <<< ConfigurationError <<< show) pure eaccounts
+        results <- deployScript
+        pure $ Tuple accounts results
+      case eDeployResults of
+        Left err -> logDeployError err *> (liftEff' $ throw "Error during deployment!")
+        Right (Tuple accounts results) -> pure { accounts
+                                               , provider
+                                               , foamCSR: results.foamCSR
+                                               , simpleStorage: results.simpleStorage
+                                               , parkingAuthority: results.parkingAuthority
+                                               }

--- a/test/Spec/SimpleStorageSpec.purs
+++ b/test/Spec/SimpleStorageSpec.purs
@@ -2,51 +2,45 @@ module SimpleStorageSpec (simpleStorageSpec) where
 
 import Prelude
 
-import ContractConfig (simpleStorageConfig)
+import Chanterelle.Internal.Test (TestConfig)
+import Data.Array ((!!))
 import Contracts.SimpleStorage as SimpleStorage
 import Control.Monad.Aff.AVar (AVAR, makeEmptyVar, putVar, takeVar)
 import Control.Monad.Aff.Class (liftAff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE, log)
-import Control.Monad.Except (runExceptT)
-import Data.Either (Either(..))
 import Data.Lens.Setter ((?~))
 import Data.Maybe (Maybe(..), fromJust)
-import Chanterelle.Internal.Deploy (readDeployAddress)
-import Network.Ethereum.Web3 (ETH, EventAction(..), _from, _gas, _to, defaultTransactionOptions, embed, event, eventFilter, runWeb3, uIntNFromBigNumber)
+import Network.Ethereum.Web3 (Address, ETH, EventAction(..), _from, _gas, _to, defaultTransactionOptions, embed, event, eventFilter, runWeb3, uIntNFromBigNumber)
 import Node.FS.Aff (FS)
-import Partial.Unsafe (unsafePartial, unsafeCrashWith)
+import Partial.Unsafe (unsafePartial, unsafePartialBecause)
 import Test.Spec (Spec, describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Type.Prelude (Proxy(..))
-import Chanterelle.Internal.Types (DeployConfig(..))
 
 simpleStorageSpec
-  :: forall e.
-     DeployConfig
+  :: forall e r.
+     TestConfig (simpleStorage :: Address | r)
   -> Spec ( fs :: FS
           , eth :: ETH
           , avar :: AVAR
           , console :: CONSOLE
           | e
           ) Unit
-simpleStorageSpec (DeployConfig deployConfig) = do
+simpleStorageSpec {provider, accounts, simpleStorage} = do
 
   describe "Setting the value of a SimpleStorage Contract" do
     it "can set the value of simple storage" $ do
-      esimpleStorageAddress <- runExceptT $ readDeployAddress simpleStorageConfig.filepath deployConfig.networkId
-      let simpleStorageAddress = case esimpleStorageAddress of
-            Right x -> x
-            Left err -> unsafeCrashWith $ "Expected SimpleStorage Address in artifact, got error" <> show err
+      let primaryAccount = unsafePartialBecause "Accounts list has at least one account" $ fromJust (accounts !! 0)
       var <- makeEmptyVar
       let n = unsafePartial $ fromJust <<< uIntNFromBigNumber <<< embed $ 42
-          txOptions = defaultTransactionOptions # _from ?~ deployConfig.primaryAccount
-                                                # _to ?~ simpleStorageAddress
+          txOptions = defaultTransactionOptions # _from ?~ primaryAccount
+                                                # _to ?~ simpleStorage
                                                 # _gas ?~ embed 90000
-      hx <- runWeb3 deployConfig.provider $ SimpleStorage.setCount txOptions {_count: n}
+      hx <- runWeb3 provider $ SimpleStorage.setCount txOptions {_count: n}
       liftEff <<< log $ "setCount tx hash: " <> show hx
-      let filterCountSet = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorageAddress
-      _ <- liftAff $ runWeb3 deployConfig.provider $
+      let filterCountSet = eventFilter (Proxy :: Proxy SimpleStorage.CountSet) simpleStorage
+      _ <- liftAff $ runWeb3 provider $
         event filterCountSet $ \e@(SimpleStorage.CountSet cs) -> do
           liftEff $ log $ "Received Event: " <> show e
           _ <- liftAff $ putVar cs._count var


### PR DESCRIPTION
Previously we were reconstructing the deploy config from files and it was really ugly. I think we should be doing deployments as _part of_ the test suite.

We can use this simple type to denote everything you might need for the test configuration
https://github.com/f-o-a-m/chanterelle/commit/da1a94e8c8c2b9940a47c3999b9397ccff99f44a

This pr is one way of doing things, it'd be nice to think about how to generalize what's going on here.