### PR TITLE
Correct spelling for ParkingAuthority.sol

### DIFF
--- a/contracts/ParkingAuthority.sol
+++ b/contracts/ParkingAuthority.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.13;
 
 /*
-  The ParkingAuthority is the governing contract for ParkingDOA. It holds two important pieces of data--
+  The ParkingAuthority is the governing contract for ParkingDAO. It holds two important pieces of data--
   the ParkingCSR, which is the crypto-spatial registry contract for all ParkingAnchors, and the user membership
-  list, which keeps track of all of the registered users of the DOA. It has the sole authority to extend these
+  list, which keeps track of all of the registered users of the DAO. It has the sole authority to extend these
   two registries.
 */
 


### PR DESCRIPTION
I corrected the spelling in lines 4 from "ParkingDOA" to  "ParkingDAO". and in line 6 from "DOA" to "DAO". I suspect this was a hidden challenge like in the movie "The Last Starfighter" to see who spotted the typo, in order to recruit for an intergalactic fleet of Starfighters. I am ready!