### PR TITLE
bump chanterelle to 0.8.3, match ps-web3 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ compile-contracts:
 deploy: compile-contracts build
 	pulp run
 
-test:
+test: compile-contracts
 	pulp test

--- a/bower.json
+++ b/bower.json
@@ -8,11 +8,11 @@
   ],
   "dependencies": {
     "purescript-prelude": "^3.1.1",
-    "purescript-web3": "^0.21.0"
+    "purescript-web3": "^0.22.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",
-    "purescript-chanterelle": "f-o-a-m/chanterelle#v0.7.0",
+    "purescript-chanterelle": "f-o-a-m/chanterelle#v0.8.3",
     "purescript-spec": "^2.0.0"
   }
 }

--- a/test/Spec/ParkingAuthoritySpec.purs
+++ b/test/Spec/ParkingAuthoritySpec.purs
@@ -20,9 +20,10 @@ import Data.String (take)
 import Data.Tuple (Tuple(..))
 import Network.Ethereum.Core.BigNumber (decimal, parseBigNumber)
 import Network.Ethereum.Core.Keccak256 (keccak256)
+import Network.Ethereum.Web3 (TransactionStatus(..))
 import Network.Ethereum.Web3.Api (eth_getAccounts)
 import Network.Ethereum.Web3.Solidity (BytesN, fromByteString)
-import Network.Ethereum.Web3.Solidity.Sizes (S256, S32, S4, S8, s32, s4, s8)
+import Network.Ethereum.Web3.Solidity.Sizes (S32, S4, S8, s32, s4, s8)
 import Network.Ethereum.Web3.Types (Address, BigNumber, ChainCursor(..), TransactionReceipt(..), ETH, Web3, _from, _gas, _to, _value, defaultTransactionOptions, embed, fromWei)
 import Node.FS.Aff (FS)
 import Partial.Unsafe (unsafeCrashWith)
@@ -116,9 +117,7 @@ parkingAuthoritySpec testCfg@{provider, accounts, foamCSR, parkingAuthority} = d
                                               # _value ?~ fromWei (embed 1)
       badHash <- User.payForParking badTxOpts {_anchor: parkingAnchorResult.anchor}
       (TransactionReceipt txReceipt) <- liftAff $ pollTransactionReceipt badHash provider
-      liftAff $ txReceipt.status `shouldEqual` "0x0"
-
-
+      liftAff $ txReceipt.status `shouldEqual` Failed
 
 --------------------------------------------------------------------------------
 -- | SetupTests


### PR DESCRIPTION
use the new TransactionStatus type as part of ps-web3 0.22